### PR TITLE
Statement throws "Cannot read property 'count' of null" when response is...

### DIFF
--- a/coin.js
+++ b/coin.js
@@ -171,7 +171,7 @@ var CoinWidgetCom = {
 						CoinWidgetCom.counter = COINWIDGETCOM_DATA;
 						$.each(CoinWidgetCom.counter,function(i,v){
 							$config = CoinWidgetCom.config[i];
-							if (!v.count || v == null) v = {count:0,amount:0};
+							if (v == null || !v.count) v = {count:0,amount:0};
 							$("span[data-coinwidget-instance='"+i+"']").find('> span').html($config.counter=='count'?v.count:(v.amount.toFixed($config.decimals)+' '+$config.lbl_amount));
 							if ($config.auto_show) {
 								$("span[data-coinwidget-instance='"+i+"']").find('> a').click();


### PR DESCRIPTION
If lookup fails and the response is null, a javascript error is returned and the loading spinner goes forever.
